### PR TITLE
Update logger to use named logger. 

### DIFF
--- a/lstm/bmi_lstm.py
+++ b/lstm/bmi_lstm.py
@@ -300,7 +300,7 @@ def gather_inputs(
         LOG.debug(f"  {value=}")
 
     collected = bmi_array(input_list)
-    LOG.debug(f"Collected inputs: {collected}")
+    LOG.debug(f"Collected inputs: %s", collected)
     return collected
 
 
@@ -308,15 +308,15 @@ def scale_inputs(
     input: npt.NDArray, mean: npt.NDArray, std: npt.NDArray
 ) -> npt.NDArray:
     LOG.debug("Normalizing the tensor...")
-    LOG.debug("  input_mean =", mean)
-    LOG.debug("  input_std  =", std)
+    LOG.debug("  input_mean = %s", mean)
+    LOG.debug("  input_std  = %s", std)
 
     # Center and scale the input values for use in torch
     input_array_scaled = (input - mean) / std
-    LOG.debug(f"### input_array ={input}")
-    LOG.debug(f"### dtype(input_array) ={input.dtype}")
-    LOG.debug(f"### type(input_array_scaled) ={type(input_array_scaled)}")
-    LOG.debug(f"### dtype(input_array_scaled) ={input_array_scaled.dtype}")
+    LOG.debug("### input_array = %s", input)
+    LOG.debug("### dtype(input_array) = %s", input.dtype)
+    LOG.debug("### type(input_array_scaled) = %s", type(input_array_scaled))
+    LOG.debug("### dtype(input_array_scaled) = %s", input_array_scaled.dtype)
     return input_array_scaled
 
 

--- a/lstm/bmi_lstm.py
+++ b/lstm/bmi_lstm.py
@@ -62,8 +62,11 @@ import yaml
 
 from . import nextgen_cuda_lstm
 from .base import BmiBase
-from .logger import configure_logging, logger
+from .logger import configure_logging, MODULE_NAME
 from .model_state import State, StateFacade, Var
+
+import logging
+LOG = logging.getLogger(MODULE_NAME)
 
 # --------------   Dynamic Attributes -----------------------------
 _dynamic_input_vars = [
@@ -282,7 +285,7 @@ def initialize_lstm(cfg: dict[str, typing.Any]) -> nextgen_cuda_lstm.Nextgen_Cud
 def gather_inputs(
     state: Valuer, internal_input_names: typing.Iterable[str]
 ) -> npt.NDArray:
-    logger.debug("Collecting LSTM inputs ...")
+    LOG.debug("Collecting LSTM inputs ...")
 
     input_list = []
     for lstm_name in internal_input_names:
@@ -291,29 +294,29 @@ def gather_inputs(
         assert value.size == 1, "`value` should a single scalar in a 1d array"
         input_list.append(value[0])
 
-        logger.debug(f"  {lstm_name=}")
-        logger.debug(f"  {bmi_name=}")
-        logger.debug(f"  {type(value)=}")
-        logger.debug(f"  {value=}")
+        LOG.debug(f"  {lstm_name=}")
+        LOG.debug(f"  {bmi_name=}")
+        LOG.debug(f"  {type(value)=}")
+        LOG.debug(f"  {value=}")
 
     collected = bmi_array(input_list)
-    logger.debug(f"Collected inputs: {collected}")
+    LOG.debug(f"Collected inputs: {collected}")
     return collected
 
 
 def scale_inputs(
     input: npt.NDArray, mean: npt.NDArray, std: npt.NDArray
 ) -> npt.NDArray:
-    logger.debug("Normalizing the tensor...")
-    logger.debug("  input_mean =", mean)
-    logger.debug("  input_std  =", std)
+    LOG.debug("Normalizing the tensor...")
+    LOG.debug("  input_mean =", mean)
+    LOG.debug("  input_std  =", std)
 
     # Center and scale the input values for use in torch
     input_array_scaled = (input - mean) / std
-    logger.debug(f"### input_array ={input}")
-    logger.debug(f"### dtype(input_array) ={input.dtype}")
-    logger.debug(f"### type(input_array_scaled) ={type(input_array_scaled)}")
-    logger.debug(f"### dtype(input_array_scaled) ={input_array_scaled.dtype}")
+    LOG.debug(f"### input_array ={input}")
+    LOG.debug(f"### dtype(input_array) ={input.dtype}")
+    LOG.debug(f"### type(input_array_scaled) ={type(input_array_scaled)}")
+    LOG.debug(f"### dtype(input_array_scaled) ={input_array_scaled.dtype}")
     return input_array_scaled
 
 
@@ -324,7 +327,7 @@ def scale_outputs(
     output_std: npt.NDArray,
     output_scale_factor_cms: float,
 ):
-    logger.debug(f"model output: {output[0, 0, 0].numpy().tolist()}")
+    LOG.debug(f"model output: {output[0, 0, 0].numpy().tolist()}")
 
     if cfg["target_variables"][0] in ["qobs_mm_per_hour", "QObs(mm/hr)", "QObs(mm/h)"]:
         surface_runoff_mm = output[0, 0, 0].numpy() * output_std + output_mean
@@ -458,7 +461,7 @@ class bmi_LSTM(BmiBase):
     def update_until(self, time: float) -> None:
         if time <= self.get_current_time():
             current_time = self.get_current_time()
-            logger.warning(f"no update performed: {time=} <= {current_time=}")
+            LOG.warning(f"no update performed: {time=} <= {current_time=}")
             return None
 
         n_steps, remainder = divmod(
@@ -466,7 +469,7 @@ class bmi_LSTM(BmiBase):
         )
 
         if remainder != 0:
-            logger.warning(
+            LOG.warning(
                 f"time is not multiple of time step size. updating until: {time - remainder=} "
             )
 

--- a/lstm/bmi_lstm.py
+++ b/lstm/bmi_lstm.py
@@ -406,15 +406,16 @@ class bmi_LSTM(BmiBase):
         self.ensemble_members: list[EnsembleMember]
 
     def initialize(self, config_file: str) -> None:
+
+        # configure the Error Warning and Trapping System logger
+        configure_logging()
+
+        LOG.info(f"Initializing with {config_file}")
+
         # read and setup main configuration file
         with open(config_file, "r") as fp:
             self.cfg_bmi = yaml.safe_load(fp)
         coerce_config(self.cfg_bmi)
-
-        # TODO: aaraney: config logging levels to python logging levels
-        # setup logging
-        # self.cfg_bmi["verbose"]
-        configure_logging()
 
         # ----------- The output is area normalized, this is needed to un-normalize it
         #                         mm->m                             km2 -> m2          hour->s

--- a/lstm/logger.py
+++ b/lstm/logger.py
@@ -1,20 +1,13 @@
-#
-# Copyright (C) 2025 Austin Raney, Lynker
-#
-# Author: Austin Raney <araney@lynker.com>
-#
+"""Logging module to integrate with NGEN"""
+
 from __future__ import annotations
 
-import logging
-
-logger = logging.getLogger()
-_configured = False
-
-import sys   
-from datetime import datetime, timezone
-import os
-import time
 import getpass
+import logging
+import os
+import sys   
+import time
+from datetime import datetime, timezone
 
 MODULE_NAME           = "LSTM";
 LOG_DIR_NGENCERF      = "/ngencerf/data";       # ngenCERF log directory string if environement var empty.
@@ -29,6 +22,8 @@ EV_MODULE_LOGLEVEL    = "LSTM_LOGLEVEL";        # This modules log level
 EV_MODULE_LOGFILEPATH = "LSTM_LOGFILEPATH";     # This modules log full log filename
 
 class CustomFormatter(logging.Formatter):
+    """A custom formatting class for logging"""
+
     LEVEL_NAME_MAP = {
         logging.DEBUG: "DEBUG",
         logging.INFO: "INFO",
@@ -36,6 +31,21 @@ class CustomFormatter(logging.Formatter):
         logging.ERROR: "SEVERE",
         logging.CRITICAL: "FATAL"
     }
+ 
+    # Apply custom formatter (UTC timestamps applied only to this formatter)
+    def converter(self, timestamp):
+        """Override time converter to return UTC time tuple"""
+        return time.gmtime(timestamp)
+
+    def formatTime(self, record, datefmt=None):
+        """Use our UTC converter"""
+        ct = self.converter(record.created)
+        if datefmt:
+            s = time.strftime(datefmt, ct)
+        else:
+            t = time.strftime("%Y-%m-%d %H:%M:%S", ct)
+            s = f"{t},{int(record.msecs):03d}"
+        return s
 
     def format(self, record):
         original_levelname = record.levelname
@@ -73,6 +83,7 @@ def get_log_file_path():
         if ngenEnvVar:
             logFilePath = ngenEnvVar
         else:
+            print(f"Module {MODULE_NAME} Env var {EV_NGEN_LOGFILEPATH} not found. Creating default log name.")
             appendEntries = False
             if os.path.isdir(LOG_DIR_NGENCERF):
                 logFileDir = LOG_DIR_NGENCERF + DS + LOG_DIR_DEFAULT
@@ -83,12 +94,12 @@ def get_log_file_path():
                 # Set full log path
                 username = getpass.getuser()
                 if username:
-                    logFieDir = logFieDir + DS + username
+                    logFileDir = logFileDir + DS + username
                 else:
                     logFileDir = logFileDir + DS + create_timestamp(True)
                 # Create directory
-                with os.makedirs(logFileDir, exist_ok=True):
-                    logFilePath = logFileDir + DS + MODULE_NAME + "_" + create_timestamp() + "." + LOG_FILE_EXT
+                os.makedirs(logFileDir, exist_ok=True)
+                logFilePath = logFileDir + DS + MODULE_NAME + "_" + create_timestamp() + "." + LOG_FILE_EXT
             except Exception as e:
                 logFilePath = ""
 
@@ -105,18 +116,16 @@ def get_log_file_path():
         else:
             raise IOError
     except:
-        print(f"Unable to open log file for {MODULE_NAME}: {logFilePath}", flush=True)
-        print(f"Log entries will be writen to stdout", flush=True)
+        print(f"Module {MODULE_NAME} Unable to open log file: {logFilePath}", flush=True)
+        print(f"Module {MODULE_NAME} Log entries will be writen to stdout", flush=True)
 
     return logFilePath, appendEntries
     
 def get_log_level() -> str:
     levelEnvVar = os.getenv(EV_MODULE_LOGLEVEL, "")
     if levelEnvVar:
-        print(f"{EV_MODULE_LOGLEVEL}={levelEnvVar}", flush=True)
         return levelEnvVar.strip().upper()
     else:
-        print(f"{EV_MODULE_LOGLEVEL} not found. Using INFO log level", flush=True)
         return "INFO"
 
 def translate_ngwpc_log_level(ngwpc_log_level: str) -> str:
@@ -126,16 +135,27 @@ def translate_ngwpc_log_level(ngwpc_log_level: str) -> str:
     elif (ll == "FATAL"):
         return "CRITICAL"
     return ll
-    
+
+def force_info(handler, logger, msg, *args):
+    record = logger.makeRecord(
+        logger.name,
+        logging.INFO,
+        __file__,
+        0,
+        msg,
+        args,
+        None,
+    )
+    handler.emit(record)
+
 def configure_logging():
     '''
     Set logging level and specify logger configuration based on environment variables set by ngen
     
     Arguments
     ---------
-    logging._Level: Log level 
-    ** Not used in NGWPC version. Instead the ngen logger defines environment variables that are read
-    
+    none
+
     Returns
     -------
     None
@@ -152,83 +172,59 @@ def configure_logging():
           it is only opened once for each ngen run (vs for each catchment)
 
     See also https://docs.python.org/3/library/logging.html
-    
+
     '''
-    global _configured # Tell Python this refers to the module-level variable
-    modulePathEnvVarSet = os.getenv(EV_MODULE_LOGFILEPATH, "")
-    if modulePathEnvVarSet and _configured:
-        return # Nothing to do — already configured, and env var is set
-    elif not modulePathEnvVarSet and _configured:
-        # Need set a log file since the ngen.log was truncated.
-        logFilePath, appendEntries = get_log_file_path()
-        if (logFilePath):
-            # Set the open mode
-            openMode = 'a' if appendEntries else 'w'
-            handler = logging.FileHandler(logFilePath, mode=openMode)
-        else:
-            handler = logging.StreamHandler(sys.stdout)
-        return
+    
+    # Use a named logger to ensure entries are identified as this
+    # MODULE_NAME and are not miss-identfied in the ngen log.
+    logger = logging.getLogger(MODULE_NAME)
+    if getattr(logger, "_initialized", False):
+        return  # logger already initialized, nothing else to do
 
     loggingEnabled = True
     moduleEnvVar = os.getenv(EV_EWTS_LOGGING, "")
     if moduleEnvVar:
-        print(f"{EV_EWTS_LOGGING}={moduleEnvVar}", flush=True)
         if (moduleEnvVar == "DISABLED"):
             loggingEnabled = False
     else:
-        print(f"{EV_EWTS_LOGGING} not found.", flush=True)
-
+        print(f"Module {MODULE_NAME} Env var {EV_EWTS_LOGGING} not found. Using logging defaults.")
+ 
     if (loggingEnabled == False):
         print(f"Module {MODULE_NAME} Logging DISABLED", flush=True)
-        logging.disable(logging.CRITICAL)  # Disables all logs at CRITICAL and below (i.e., everything)
+        logger.disabled = True  # Disables all logs at CRITICAL and below (i.e., everything)
     else:
         print(f"Module {MODULE_NAME} Logging ENABLED", flush=True)
-
-        # Get the log file name from env var or a default 
+ 
+        # Get the log file name from env var or a default
         logFilePath, appendEntries = get_log_file_path()
         if (logFilePath):
             # Set the open mode
             openMode = 'a' if appendEntries else 'w'
             handler = logging.FileHandler(logFilePath, mode=openMode)
         else:
+            print(f"Module {MODULE_NAME} unable to create log file. Using stdout.")
             handler = logging.StreamHandler(sys.stdout)
-
+ 
         # Get the log level from env var or a default
         log_level = get_log_level()
-
+ 
         # Format the module name: uppercase, fixed length, left-justify or trimmed
         formatted_module = MODULE_NAME.upper().ljust(LOG_MODULE_NAME_LEN)[:LOG_MODULE_NAME_LEN]
-
+ 
         # Apply custom formatter
-        formatted_module = MODULE_NAME.upper().ljust(LOG_MODULE_NAME_LEN)[:LOG_MODULE_NAME_LEN]
         formatter = CustomFormatter(
             fmt=f"%(asctime)s.%(msecs)03d {formatted_module} %(levelname_padded)s %(message)s",
             datefmt="%Y-%m-%dT%H:%M:%S"
         )
         handler.setFormatter(formatter)
-
-        # Setup root logger
-        logging.getLogger().handlers.clear()  # Clear any default handlers
-        logging.getLogger().setLevel(translate_ngwpc_log_level(log_level))
-        logging.getLogger().addHandler(handler)
-
-        # Ensure UTC timestamps
-        logging.Formatter.converter = time.gmtime
-
-        # Save the current log level
-        current_level = logging.getLogger().getEffectiveLevel()
-
-        try:
-            # Temporarily set log level to INFO
-            logging.getLogger().setLevel(logging.INFO)
-            
-            # Log the message at INFO level
-            logging.info(f"Log level set to {log_level}")
-            print(f"Module {MODULE_NAME} Log Level set to {log_level}", flush=True)
-        finally:
-            # Restore the original log level
-            logging.getLogger().setLevel(current_level)
-
-    # Set this true so the logger is only configured once
-    _configured = True
  
+        # Setup logger
+        logger.handlers.clear()  # Clear any default handlers
+        logger.setLevel(translate_ngwpc_log_level(log_level))
+        logger.addHandler(handler)
+ 
+        # Write log level INFO message to log regradless of the actual log level
+        force_info(handler, logger, "Log level set to %s", log_level)
+        print(f"Module {MODULE_NAME} Log Level set to {log_level}", flush=True)
+
+    logger._initialized = True

--- a/lstm/run_lstm_bmi.py
+++ b/lstm/run_lstm_bmi.py
@@ -7,7 +7,10 @@ from pathlib import Path
 from netCDF4 import Dataset
 # This is the BMI LSTM that we will be running
 import bmi_lstm
-from .logger import logger
+from .logger import MODULE_NAME
+
+import logging
+LOG = logging.getLogger(MODULE_NAME)
 
 # Define primary bmi config and input data file paths 
 #bmi_cfg_file=Path('./bmi_config_files/01022500_hourly_all_attributes_forcings.yml')
@@ -17,19 +20,19 @@ bmi_cfg_file  = run_dir + 'bmi_config_files/01022500_hourly_slope_mean_precip_te
 sample_data_file = run_dir + 'data/usgs-streamflow-nldas_hourly.nc'
 
 # creating an instance of an LSTM model
-logger.debug('Creating an instance of an BMI_LSTM model object')
+LOG.debug('Creating an instance of an BMI_LSTM model object')
 model = bmi_lstm.bmi_LSTM()
 
 # Initializing the BMI
-logger.debug('Initializing the BMI')
+LOG.debug('Initializing the BMI')
 model.initialize(bmi_cfg_file)
 
 # Get input data that matches the LSTM test runs
-logger.debug('Gathering input data')
+LOG.debug('Gathering input data')
 sample_data = Dataset(sample_data_file, 'r')
 
 # Now loop through the inputs, set the forcing values, and update the model
-logger.debug('Set values & update model for number of timesteps = 100')
+LOG.debug('Set values & update model for number of timesteps = 100')
 for precip, temp in zip(list(sample_data['total_precipitation'][3].data),
                         list(sample_data['temperature'][3].data)):
 
@@ -44,8 +47,8 @@ for precip, temp in zip(list(sample_data['total_precipitation'][3].data),
     #model.get_value('atmosphere_water__liquid_equivalent_precipitation_rate', dest_array)
     #precips = dest_array[0]
 
-    #logger.debug(' Temperature and precipitation are set to {:.2f} and {:.2f}'.format(temperature, precip))
-    logger.debug(' Temperature and precipitation are set to {:.2f} and {:.2f}'.format(temp, precip))
+    #LOG.debug(' Temperature and precipitation are set to {:.2f} and {:.2f}'.format(temperature, precip))
+    LOG.debug(' Temperature and precipitation are set to {:.2f} and {:.2f}'.format(temp, precip))
     #model.update_until(model.t+model._time_step_size)
     model.update()
 
@@ -53,12 +56,12 @@ for precip, temp in zip(list(sample_data['total_precipitation'][3].data),
     model.get_value('land_surface_water__runoff_volume_flux', dest_array)
     runoff = dest_array[0]
 
-    logger.debug(' Streamflow (cms) at time {} ({}) is {:.2f}'.format(model.get_current_time(), model.get_time_units(), runoff))
+    LOG.debug(' Streamflow (cms) at time {} ({}) is {:.2f}'.format(model.get_current_time(), model.get_time_units(), runoff))
 
     if model.t > 100:
-        #logger.debug('Stopping the loop')
+        #LOG.debug('Stopping the loop')
         break
 
 # Finalizing the BMI
-logger.debug('Finalizing the BMI')
+LOG.debug('Finalizing the BMI')
 model.finalize()


### PR DESCRIPTION
To avoid possible collisions with other loggers or the root logger, use a named logger instead of the root logger. Updated statements to be consistent across EWTS loggers.

## Additions

- Added an INFO log message during LSTM initialization to ensure the named logger worked once configured. LSTM did not have any `LOG.info` messages so this produces the least number of entries yet still accomplish what was needed. 

## Changes

- Configure the EWTS logger as a named logger instead of configuring the root logger.
- Converted `logger.` log statements to `LOG.` to be consistent across EWTS loggers.
- Fixed debug log statements missing format specifiers

## Testing

1. Ran LSTM in my local AWS workspace and observed the LSTM log messages in ngen.log

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)

