### PR TITLE
Merge OWP Master Changes into Development (NGWPC-9802)

### DIFF
--- a/lstm/bmi_lstm.py
+++ b/lstm/bmi_lstm.py
@@ -59,6 +59,10 @@ import numpy.typing as npt
 import pandas as pd
 import torch
 import yaml
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader
 
 from . import nextgen_cuda_lstm
 from .base import BmiBase
@@ -147,7 +151,7 @@ class EnsembleMember:
         # load training feature scales
         scaler_file = cfg["run_dir"] / "train_data/train_data_scaler.yml"
         with scaler_file.open("r") as fp:
-            train_data_scaler = yaml.safe_load(fp)
+            train_data_scaler = yaml.load(fp, Loader=SafeLoader)
         self.scalars = load_training_scalars(cfg, train_data_scaler)
 
         # initialize torch lstm object
@@ -428,7 +432,7 @@ class bmi_LSTM(BmiBase):
 
         # read and setup main configuration file
         with open(config_file, "r") as fp:
-            self.cfg_bmi = yaml.safe_load(fp)
+            self.cfg_bmi = yaml.load(fp, Loader=SafeLoader)
         coerce_config(self.cfg_bmi)
 
         # ----------- The output is area normalized, this is needed to un-normalize it
@@ -440,7 +444,7 @@ class bmi_LSTM(BmiBase):
         # initialize ensemble members
         self.ensemble_members = []
         for member_cfg_file in self.cfg_bmi["train_cfg_file"]:
-            cfg = yaml.safe_load(member_cfg_file.read_text())
+            cfg = yaml.load(member_cfg_file.read_text(), Loader=SafeLoader)
             coerce_config(cfg)
             member = EnsembleMember(cfg, output_factor_cms)
             self.ensemble_members.append(member)


### PR DESCRIPTION
Merge into the development branch changes in the `master` branch of the parent OWP repository. The changes accepted are limited to how loading the config YAML files are handled. Rejected changes were related to how logging was getting called. The logging messages were the exact same between OWP And NGWPC, but OWP's logging didn't use the global `LOG` object and did not use f-strings for simplifying messages.

## Changes

- `yaml.save_load(...)` converted to `yaml.load(..., Loader=SafeLoader)`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [x] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
