### PR TITLE
Exclude or include or EWTS

### DIFF
--- a/lstm/bmi_lstm.py
+++ b/lstm/bmi_lstm.py
@@ -77,11 +77,6 @@ try:
     LSTM_USE_EWTS = True
 except ImportError:
     LSTM_USE_EWTS = False
-    logging.basicConfig(
-        level=logging.DEBUG,
-        format='%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(lineno)s - %(funcName)s]: %(message)s',
-    )
-
 
 import os
 
@@ -457,7 +452,19 @@ def load_static_attributes(cfg: dict[str, typing.Any], state: State):
         value = cfg[internal_name]
         state.set_value(external_name, bmi_array([value]))
 
+def _configure_stdout_logging():
+    LOG.setLevel(logging.INFO)
 
+    if not LOG.handlers:
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - "
+            "[%(filename)s:%(lineno)s - %(funcName)s]: %(message)s"
+        ))
+        LOG.addHandler(handler)
+
+    LOG.propagate = False
 class bmi_LSTM(BmiBase):
     _timestep_size_s: typing.Final[int] = 3600
     """model timestep size in seconds"""
@@ -469,9 +476,12 @@ class bmi_LSTM(BmiBase):
             # into the ngen Python interpreter to ensure the env vars are set.
             val = getenv_any("EWTS_USE_NGEN_BRIDGE", "").strip().lower()
             if val in {"1", "true", "yes", "on"}:
-                configure_existing_logger(LOG) # Reconfigure logger for EWTS logging
+                configure_existing_logger(LOG)
             else:
-                LOG.warning("EWTS installed but EWTS_USE_NGEN_BRIDGE not on. Falling back to default logging.")
+                _configure_stdout_logging()
+                LOG.warning("EWTS importable but EWTS_USE_NGEN_BRIDGE not on. Falling back to default logging.")
+        else:
+            _configure_stdout_logging()
 
         # _bmi_ variable state; this is separate from lstm ensemble member state.
         self._dynamic_inputs = build_state(_dynamic_input_vars)

--- a/lstm/bmi_lstm.py
+++ b/lstm/bmi_lstm.py
@@ -70,9 +70,45 @@ from . import nextgen_cuda_lstm
 from .base import BmiBase
 from .model_state import State, StateFacade, Var
 
-import ewts
-LOG = ewts.get_logger(ewts.LSTM_ID)
+LOG = logging.getLogger("LSTM")
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(lineno)s - %(funcName)s]: %(message)s',
+)
 
+import os
+
+# NOTE: Helper function to ensure reading env vars
+# When run within ngen some env vars are set from C++ after the 
+# Python interpreter has started.
+# In embedded Python, os.environ may not reflect those changes.
+# getenv_any() falls back to libc getenv() and syncs os.environ.
+def getenv_any(key: str, default: str = "") -> str:
+    """
+    Get an environment variable reliably even when it is set from C/C++
+    after the Python interpreter has started (embedded Python).
+    Prefers os.environ/os.getenv, falls back to libc getenv.
+    """
+    # First try Python's mapping
+    v = os.environ.get(key)
+    if v is not None:
+        return v
+
+    # Fallback: direct libc getenv (sees process env even if Python mapping is stale)
+    try:
+        import ctypes, ctypes.util
+        libc = ctypes.CDLL(ctypes.util.find_library("c"))
+        libc.getenv.restype = ctypes.c_char_p
+        b = libc.getenv(key.encode("utf-8"))
+        if not b:
+            return default
+        s = b.decode("utf-8")
+
+        # Sync back into os.environ so future lookups work normally
+        os.environ[key] = s
+        return s
+    except Exception:
+        return default
 
 # --------------   Dynamic Attributes -----------------------------
 _dynamic_input_vars = [
@@ -420,6 +456,21 @@ class bmi_LSTM(BmiBase):
     """model timestep size in seconds"""
 
     def __init__(self) -> None:
+
+        # Determine if running within ngen using EWTS. This must be done  
+        # here when the model actually runs vs when it is imported 
+        # into the ngen Python interpreter to ensure the env vars are set.
+        val = getenv_any("EWTS_USE_NGEN_BRIDGE", "").strip().lower()
+        if val in {"1", "true", "yes", "on"}:
+            try:
+                from ewts.logger import configure_existing_logger
+            except ImportError:
+                LOG.warning("EWTS_USE_NGEN_BRIDGE is set, but EWTS package is not installed. Falling back to default logging.")
+                return
+
+            # Reconfigure logger for EWTS logging
+            configure_existing_logger(LOG)
+
         # _bmi_ variable state; this is separate from lstm ensemble member state.
         self._dynamic_inputs = build_state(_dynamic_input_vars)
         self._static_inputs = build_state(_static_input_vars)
@@ -441,9 +492,6 @@ class bmi_LSTM(BmiBase):
 
     def initialize(self, config_file: str) -> None:
 
-        # This is required prior to the first log message is issued by t-route.
-        LOG.bind()
-        
         LOG.info(f"Initializing with {config_file}")
 
         # read and setup main configuration file

--- a/lstm/bmi_lstm.py
+++ b/lstm/bmi_lstm.py
@@ -71,10 +71,17 @@ from .base import BmiBase
 from .model_state import State, StateFacade, Var
 
 LOG = logging.getLogger("LSTM")
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(lineno)s - %(funcName)s]: %(message)s',
-)
+try:
+    from ewts.helper import getenv_any
+    from ewts.logger import configure_existing_logger
+    LSTM_USE_EWTS = True
+except ImportError:
+    LSTM_USE_EWTS = False
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format='%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(lineno)s - %(funcName)s]: %(message)s',
+    )
+
 
 import os
 
@@ -456,20 +463,15 @@ class bmi_LSTM(BmiBase):
     """model timestep size in seconds"""
 
     def __init__(self) -> None:
-
-        # Determine if running within ngen using EWTS. This must be done  
-        # here when the model actually runs vs when it is imported 
-        # into the ngen Python interpreter to ensure the env vars are set.
-        val = getenv_any("EWTS_USE_NGEN_BRIDGE", "").strip().lower()
-        if val in {"1", "true", "yes", "on"}:
-            try:
-                from ewts.logger import configure_existing_logger
-            except ImportError:
-                LOG.warning("EWTS_USE_NGEN_BRIDGE is set, but EWTS package is not installed. Falling back to default logging.")
-                return
-
-            # Reconfigure logger for EWTS logging
-            configure_existing_logger(LOG)
+        if LSTM_USE_EWTS:
+            # Determine if running within ngen using EWTS. This must be done  
+            # here when the model actually runs vs when it is imported 
+            # into the ngen Python interpreter to ensure the env vars are set.
+            val = getenv_any("EWTS_USE_NGEN_BRIDGE", "").strip().lower()
+            if val in {"1", "true", "yes", "on"}:
+                configure_existing_logger(LOG) # Reconfigure logger for EWTS logging
+            else:
+                LOG.warning("EWTS installed but EWTS_USE_NGEN_BRIDGE not on. Falling back to default logging.")
 
         # _bmi_ variable state; this is separate from lstm ensemble member state.
         self._dynamic_inputs = build_state(_dynamic_input_vars)

--- a/lstm/bmi_lstm.py
+++ b/lstm/bmi_lstm.py
@@ -53,6 +53,7 @@ import collections
 import typing
 from dataclasses import dataclass
 from pathlib import Path
+from datetime import datetime, timezone
 import logging
 
 import numpy as np
@@ -452,19 +453,42 @@ def load_static_attributes(cfg: dict[str, typing.Any], state: State):
         value = cfg[internal_name]
         state.set_value(external_name, bmi_array([value]))
 
+class StdoutStyleFormatter(logging.Formatter):
+
+    INFO_FORMAT = (
+        "%(asctime)s %(name)-8s %(levelname)-7s %(message)s"
+    )
+
+    DETAILED_FORMAT = (
+        "%(asctime)s %(name)-8s %(levelname)-7s "
+        "%(message)s "
+        "[%(filename)s.%(funcName)s(L%(lineno)s)]"
+    )
+
+    def format(self, record):
+        if record.levelno == logging.INFO:
+            self._style._fmt = self.INFO_FORMAT
+        else:
+            self._style._fmt = self.DETAILED_FORMAT
+
+        return super().format(record)
+    
+    def formatTime(self, record, datefmt=None):
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+    
+
 def _configure_stdout_logging():
     LOG.setLevel(logging.INFO)
 
     if not LOG.handlers:
         handler = logging.StreamHandler()
         handler.setLevel(logging.INFO)
-        handler.setFormatter(logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - "
-            "[%(filename)s:%(lineno)s - %(funcName)s]: %(message)s"
-        ))
+        handler.setFormatter(StdoutStyleFormatter())
         LOG.addHandler(handler)
 
     LOG.propagate = False
+
 class bmi_LSTM(BmiBase):
     _timestep_size_s: typing.Final[int] = 3600
     """model timestep size in seconds"""
@@ -479,7 +503,7 @@ class bmi_LSTM(BmiBase):
                 configure_existing_logger(LOG)
             else:
                 _configure_stdout_logging()
-                LOG.warning("EWTS importable but EWTS_USE_NGEN_BRIDGE not on. Falling back to default logging.")
+                LOG.warning("ewts package installed but EWTS_USE_NGEN_BRIDGE not on. Falling back to default logging.")
         else:
             _configure_stdout_logging()
 

--- a/lstm/run_lstm_bmi.py
+++ b/lstm/run_lstm_bmi.py
@@ -7,10 +7,13 @@ from pathlib import Path
 from netCDF4 import Dataset
 # This is the BMI LSTM that we will be running
 import bmi_lstm
-from .logger import MODULE_NAME
 
 import logging
-LOG = logging.getLogger(MODULE_NAME)
+LOG = logging.getLogger("LSTM")
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(lineno)s - %(funcName)s]: %(message)s',
+)
 
 # Define primary bmi config and input data file paths 
 #bmi_cfg_file=Path('./bmi_config_files/01022500_hourly_all_attributes_forcings.yml')


### PR DESCRIPTION
Update to reconfigure a native Python logger to an EWTS logger when the ewts package is installed and the `EWTS_USE_NGEN_BRIDGE` environment variable set by ngen indicates to use ewts for logging.

## Additions

- Call to `configure_existing_logger` when ewts is present and `EWTS_USE_NGEN_BRIDGE` is true
- Logs to stdout follow same format pattern currently used by ewts, <timestamp> <module> <log level> <message>. If log level above INFO, the filename, method name and line number also appended to the log message.

## Removals

- Importing ewts in all modules that log

## Changes

- Change setting `LOG` from the ewts named logger to an Python logger named `LSTM` 

## Testing

1. Tested with docker build command build argument `USE_EWTS` set `ON` 
2. Tested with docker build command build argument `USE_EWTS` set `OFF`
3. Tested with docker build command build argument `USE_EWTS` not set, which defaults to `ON`